### PR TITLE
Serve the original variants if no experiments are set-up in the redux…

### DIFF
--- a/module/experiment.js
+++ b/module/experiment.js
@@ -2,13 +2,13 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Variant } from './variant'
-import { setExperimentVariant } from './actions'
 
 export function Selector (props) {
 	const { variant, name, children } = props
 	let chosenOne
+
 	React.Children.forEach(children, child => {
-		if (child.type === Variant && child.props.name === variant) {
+		if (child.type === Variant && child.props.name === (variant || 'original')) {
 			chosenOne = React.cloneElement(child, { experiment: name })
 		}
 	})
@@ -19,10 +19,8 @@ Selector.propTypes = {
 	name: PropTypes.string.isRequired,
 }
 
-const mapStateToProps = (state, ownProps) => {
-	return {
+export const Experiment = connect(
+    (state, ownProps) => ({
 		variant: state.experiments[ownProps.name] || null
-	}
-}
-
-export const Experiment = connect(mapStateToProps)(Selector)
+	})
+)(Selector)

--- a/module/reducer.js
+++ b/module/reducer.js
@@ -14,6 +14,10 @@ function getRandomVariant(experiment) {
 	return choose(experiment.variants)
 }
 
+function findVariant(experiment, variantName) {
+	return experiment && experiment.variants.find(variant => variant.name === variantName)
+}
+
 export function createExperiments (experiments) {
 	function generateRandomState() {
 		const initialState = {}
@@ -31,18 +35,21 @@ export function createExperiments (experiments) {
 				const newState = {}
 				for (let key in state) {
 					if (action.state.hasOwnProperty(key) && state.hasOwnProperty(key)) {
-						newState[key] = action.state[key]
-					}
-					else {
-						newState[key] = state[key]
+						if (findVariant(experiments[key], action.state[key])) {
+							newState[key] = action.state[key]
+						}
 					}
 				}
-				return newState
+				return Object.assign({}, state, newState)
 			}
 
-			case 'SET_EXPERIMENT_VARIANT':
-				return Object.assign({}, state, {[action.experiment]: action.variant})
-
+			case 'SET_EXPERIMENT_VARIANT': {
+				if (findVariant(experiments[action.experiment], action.variant)) {
+					return Object.assign({}, state, { [action.experiment]: action.variant })
+				} else {
+					return state
+				}
+			}
 			default:
 				return state
 		}

--- a/test/experiment_tests.js
+++ b/test/experiment_tests.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { Selector } from '../module/experiment'
 import { Variant } from '../module/variant'
-import { reducer } from '../module/reducer'
 import assert from 'assert'
 
 
@@ -24,5 +23,14 @@ describe('Selector component', () => {
 				<Variant name="green"><span>Green</span></Variant>
 			</Selector>)
 		assert.equal(selector.contains(<span>Blue</span>), true)
+	})
+
+	it ('Should render the original variant if experiment is not in store', () => {
+		const selector = shallow(<Selector name="button" addExperiment={() => null}>
+				<Variant name="blue"><span>Blue</span></Variant>
+				<Variant name="red"><span>Red</span></Variant>
+				<Variant name="original"><span>Original</span></Variant>
+			</Selector>)
+		assert.equal(selector.contains(<span>Original</span>), true)
 	})
 })

--- a/test/redux_tests.js
+++ b/test/redux_tests.js
@@ -12,18 +12,16 @@ describe ('Experiments reducer', () => {
 		)
 	})
 
-	it ('Should handle a new experiment', () => {
-		assert.deepEqual(
-			reducer({cta: 'Buy it now'}, {
-				type: 'SET_EXPERIMENT_VARIANT',
-				experiment: 'button',
-				variant: 'green'
-			}),
-			{button: 'green', cta: 'Buy it now'}
-		)
-	})
-
 	it ('Should change the variant of an existing experiment', () => {
+		const reducer = createExperiments({
+			button: {
+				variants: [
+					{name: 'green'},
+					{name: 'red'},
+					{name: 'blue'}
+				]
+			}
+		})
 		assert.deepEqual(
 			reducer({button: 'green'}, {
 				type: 'SET_EXPERIMENT_VARIANT',
@@ -31,6 +29,25 @@ describe ('Experiments reducer', () => {
 				variant: 'red'
 			}),
 			{button: 'red'}
+		)
+	})
+
+	it ('Should not change the variant if experiment does not have the given variant', () => {
+		const reducer = createExperiments({
+			button: {
+				variants: [
+					{name: 'green'},
+					{name: 'blue'}
+				]
+			}
+		})
+		assert.deepEqual(
+			reducer({button: 'green'}, {
+				type: 'SET_EXPERIMENT_VARIANT',
+				experiment: 'button',
+				variant: 'red'
+			}),
+			{button: 'green'}
 		)
 	})
 
@@ -50,9 +67,35 @@ describe ('Experiments reducer', () => {
 			}
 		})
 
-		const loadedState = {'btnExp': 'green'}
-		const finalState = reducer(undefined, {type: 'LOAD_EXPERIMENTS_VARIANTS', state: loadedState})
-		assert.equal(finalState.btnExp, 'green')
+		const initialState = {'btnExp': 'blue', 'titleExp': 'small'}
+		const loadedState = {'btnExp': 'red'}
+		const finalState = reducer(initialState, {type: 'LOAD_EXPERIMENTS_VARIANTS', state: loadedState})
+		assert.equal(finalState.btnExp, 'red')
+		assert.equal(finalState.titleExp, 'small')
+		assert(finalState.titleExp.length > 2)
+	})
+
+	it ('Should not load invalid variants in state', () => {
+		const reducer = createExperiments({
+			'btnExp': {
+				variants: [
+					{name: 'blue'},
+					{name: 'red'}
+				]
+			},
+			'titleExp': {
+				variants: [
+					{name: 'big'},
+					{name: 'small'}
+				]
+			}
+		})
+
+		const initialState = {'btnExp': 'red', 'titleExp': 'big'}
+		const loadedState = {'btnExp': 'green', 'titleExp': 'small'}
+		const finalState = reducer(initialState, {type: 'LOAD_EXPERIMENTS_VARIANTS', state: loadedState})
+		assert.equal(finalState.btnExp, 'red')
+		assert.equal(finalState.titleExp, 'small')
 		assert(finalState.titleExp.length > 2)
 	})
 


### PR DESCRIPTION
… store

- Add check for LOAD_EXPERIMENTS_VARIANTS and SET_EXPERIMENT_VARIANT to verify if the variant is in the experiments object. In case the experiment name or some variant name changes, and we set it form cookie with the old name, now the application will not break. Before if we set an invalid variant for an experiment the component wouldn't get displayed. 
- If the experiment is not in the experiments list (the list used in createExperiments) the original variant will be displayed. If the experiment is not added in the experiments list, the component will still be displayed with original variant.